### PR TITLE
WIP: Fix failing update mock chirp action

### DIFF
--- a/src/wwara_chirp/update_mock_chirp.py
+++ b/src/wwara_chirp/update_mock_chirp.py
@@ -1,112 +1,180 @@
-# This script is intended to be run as a GitHub Action to update the mock_chirp.py
-# file in the wwara_chirp repository. It compares the constants in mock_chirp.py
-# with those in chirp_common.py and updates them if necessary. If any updates are
-# made, it creates a pull request to merge the changes into the dev branch.
+# This script is intended to be run as a GitHub Action to update the
+# mock_chirp.py file in the wwara_chirp repository. It compares the
+# constants in mock_chirp.py with those in chirp_common.py and updates
+# them if necessary. If any updates are made, it creates a pull request
+# to merge the changes into the dev branch.
 
+import ast
 import os
 import subprocess
-import ast
+
 import requests
 from github import Github
 
+
 class UpdateMockChirp:
     REPO_URL = "https://github.com/tsayles/wwara_chirp.git"
-    CHIRP_COMMON_URL = "https://raw.githubusercontent.com/kk7ds/chirp/refs/heads/master/chirp/chirp_common.py"
+    CHIRP_COMMON_URL = (
+        "https://raw.githubusercontent.com/kk7ds/chirp/refs/heads/master/"
+        "chirp/chirp_common.py"
+    )
     CHIRP_COMMON_FILENAME = "chirp_common.py"
     MOCK_CHIRP_FILENAME = "src/wwara_chirp/mock_chirp.py"
     BRANCH_NAME = "update-mock-chirp"
     GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
     REPO_NAME = "tsayles/wwara_chirp"
     BASE_BRANCH = "dev"
+    MOCK_CHIRP_CLASS_NAME = "MockChirp"
 
     def __init__(self):
         self.constants = {}
 
     def clone_repo(self):
-        subprocess.run(["git", "clone", self.REPO_URL])
+        subprocess.run(["git", "clone", self.REPO_URL], check=True)
         os.chdir("wwara_chirp")
-        subprocess.run(["git", "checkout", self.BASE_BRANCH])
-        subprocess.run(["git", "pull", "origin", self.BASE_BRANCH])
+        subprocess.run(["git", "checkout", self.BASE_BRANCH], check=True)
+        subprocess.run(["git", "pull", "origin", self.BASE_BRANCH], check=True)
 
     def download_chirp_common(self):
-        response = requests.get(self.CHIRP_COMMON_URL)
-        with open(self.CHIRP_COMMON_FILENAME, "w") as file:
+        response = requests.get(self.CHIRP_COMMON_URL, timeout=30)
+        response.raise_for_status()
+        with open(self.CHIRP_COMMON_FILENAME, "w", encoding="utf-8") as file:
             file.write(response.text)
 
+    @staticmethod
+    def _parse_uppercase_assignments(tree):
+        constants = {}
+        for node in tree.body:
+            if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+                continue
+            target = node.targets[0]
+            if not isinstance(target, ast.Name) or not target.id.isupper():
+                continue
+            try:
+                constants[target.id] = ast.literal_eval(node.value)
+            except ValueError:
+                continue
+        return constants
+
+    @staticmethod
+    def _get_mock_chirp_class(tree):
+        for node in tree.body:
+            if (
+                isinstance(node, ast.ClassDef)
+                and node.name == UpdateMockChirp.MOCK_CHIRP_CLASS_NAME
+            ):
+                return node
+        raise ValueError("MockChirp class not found in mock_chirp.py")
+
     def parse_chirp_common(self):
-        # Open 'chirp_common.py' and read its contents
-        with open(self.CHIRP_COMMON_FILENAME, "r") as file:
-            chirp_common = file.read()
-
-        # Create a controlled environment for execution
-        local_vars = {}
-        exec(chirp_common, {}, local_vars)
-
-        # Filter out constants (uppercase variable names)
-        chirp_common_constants = {
-            key: value for key, value in local_vars.items() if key.isupper()
-        }
-
-        return chirp_common_constants
+        with open(self.CHIRP_COMMON_FILENAME, "r", encoding="utf-8") as file:
+            chirp_common = ast.parse(file.read(), self.CHIRP_COMMON_FILENAME)
+        return self._parse_uppercase_assignments(chirp_common)
 
     def parse_mock_chirp(self):
-        # Open 'src/wwara_chirp/mock_chirp.py' and read its contents
-        # with open("src/wwara_chirp/mock_chirp.py", "r") as file:
-        with open(self.MOCK_CHIRP_FILENAME, "r") as file:
-            mock_chirp = file.read()
-        # Parse the contents of 'mock_chirp.py' as a dictionary
-        mock_constants = ast.literal_eval(mock_chirp)
-        # Filter constants that are uppercase from mock_constants
-        return {k: v for k, v in mock_constants.items() if k.isupper()}
+        with open(self.MOCK_CHIRP_FILENAME, "r", encoding="utf-8") as file:
+            mock_chirp = ast.parse(file.read(), self.MOCK_CHIRP_FILENAME)
+        mock_chirp_class = self._get_mock_chirp_class(mock_chirp)
+        return self._parse_uppercase_assignments(mock_chirp_class)
 
     def compare_constants(self, common_constants, mock_constants):
         updated = False
-        # Iterate over the items in common_constants
-        for key, value in common_constants.items():
-            # Check if the key exists in mock_constants and if the values are different
-            if key in mock_constants and mock_constants[key] != value:
-                # Update the value in mock_constants to match the value in common_constants
-                mock_constants[key] = value
+        updated_mock_constants = dict(mock_constants)
+        for key, mock_value in mock_constants.items():
+            if key not in common_constants:
+                continue
+            common_value = common_constants[key]
+            if mock_value != common_value:
+                updated_mock_constants[key] = common_value
                 updated = True
-            # If the key does not exist in mock_constants, add it
-            elif key not in mock_constants:
-                mock_constants[key] = value
-                updated = True
-        return updated, mock_constants
+        return updated, updated_mock_constants
 
     def update_mock_chirp(self, mock_constants):
-        # Write the updated mock_constants back to 'mock_chirp.py'
-        with open(self.MOCK_CHIRP_FILENAME, "w") as file:
-            file.write(str(mock_constants))
+        with open(self.MOCK_CHIRP_FILENAME, "r", encoding="utf-8") as file:
+            source = file.read()
+
+        tree = ast.parse(source, self.MOCK_CHIRP_FILENAME)
+        mock_chirp_class = self._get_mock_chirp_class(tree)
+        replacements = []
+        lines = source.splitlines(keepends=True)
+
+        for node in mock_chirp_class.body:
+            if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+                continue
+            target = node.targets[0]
+            if (
+                not isinstance(target, ast.Name)
+                or target.id not in mock_constants
+            ):
+                continue
+            start_line = node.lineno - 1
+            end_line = node.end_lineno
+            start = sum(len(line) for line in lines[:start_line])
+            end = sum(len(line) for line in lines[:end_line])
+            indent = " " * node.col_offset
+            replacement = (
+                f"{indent}{target.id} = "
+                f"{repr(mock_constants[target.id])}\n"
+            )
+            replacements.append((start, end, replacement))
+
+        for start, end, replacement in reversed(replacements):
+            source = source[:start] + replacement + source[end:]
+
+        with open(self.MOCK_CHIRP_FILENAME, "w", encoding="utf-8") as file:
+            file.write(source)
 
     def commit_and_create_pr(self):
-        subprocess.run(["git", "config", "--global", "user.name", "github-actions[bot]"])
-        subprocess.run(["git", "config", "--global", "user.email", "github-actions[bot]@users.noreply.github.com"])
-        subprocess.run(["git", "checkout", "-b", self.BRANCH_NAME])
-        subprocess.run(["git", "add", "src/wwara_chirp/mock_chirp.py"])
-        subprocess.run(["git", "commit", "-m", "Update mock_chirp.py with latest constants from chirp_common.py"])
-        subprocess.run(["git", "push", "origin", self.BRANCH_NAME])
+        subprocess.run(
+            ["git", "config", "--global", "user.name", "github-actions[bot]"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "config",
+                "--global",
+                "user.email",
+                "github-actions[bot]@users.noreply.github.com",
+            ],
+            check=True,
+        )
+        subprocess.run(["git", "checkout", "-b", self.BRANCH_NAME], check=True)
+        subprocess.run(["git", "add", self.MOCK_CHIRP_FILENAME], check=True)
+        subprocess.run(
+            [
+                "git",
+                "commit",
+                "-m",
+                "Update mock_chirp.py with latest constants from "
+                "chirp_common.py",
+            ],
+            check=True,
+        )
+        subprocess.run(["git", "push", "origin", self.BRANCH_NAME], check=True)
 
         g = Github(self.GITHUB_TOKEN)
         repo = g.get_repo(self.REPO_NAME)
         repo.create_pull(
             title="Update mock_chirp.py with latest constants",
-            body="This PR updates mock_chirp.py with the latest constants from chirp_common.py",
+            body=(
+                "This PR updates mock_chirp.py with the latest constants "
+                "from chirp_common.py"
+            ),
             head=self.BRANCH_NAME,
-            base=self.BASE_BRANCH
+            base=self.BASE_BRANCH,
         )
+
 
 def main():
     print("Updating mock_chirp.py with latest constants")
     updater = UpdateMockChirp()
 
-    # Check if the script is being run in the correct directory
     pwd = os.getcwd()
     print(f"Current working directory: {pwd}")
 
-    # Create a clean {{repo}}/updater directory for the update process
     if os.path.exists("updater"):
-        subprocess.run(["rm", "-rf", "updater"])
+        subprocess.run(["rm", "-rf", "updater"], check=True)
     os.makedirs("updater")
     os.chdir("updater")
 
@@ -114,16 +182,18 @@ def main():
     updater.download_chirp_common()
     common_constants = updater.parse_chirp_common()
     mock_constants = updater.parse_mock_chirp()
-    updated, updated_mock_constants = updater.compare_constants(common_constants, mock_constants)
+    updated, updated_mock_constants = updater.compare_constants(
+        common_constants,
+        mock_constants,
+    )
     if updated:
         updater.update_mock_chirp(updated_mock_constants)
         updater.commit_and_create_pr()
     else:
         print("No updates needed. mock_chirp.py is already up to date.")
 
-    # Clean up the updater directory
     os.chdir("..")
-    subprocess.run(["rm", "-rf", "updater"])
+    subprocess.run(["rm", "-rf", "updater"], check=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_update_mock_chirp.py
+++ b/tests/test_update_mock_chirp.py
@@ -1,82 +1,116 @@
-# This file trys to replicate and test the behavior update_mock_chirp.py
-# when run in a GitHub Actions environment.
-
-import os
-import unittest
 import ast
+import os
+import tempfile
+import unittest
+
 from src.wwara_chirp.update_mock_chirp import UpdateMockChirp
+
 
 class TestUpdateMockChirp(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        # Create necessary test data files
-        cls.create_test_data_files()
-
-    @classmethod
-    def tearDownClass(cls):
-        # Clean up test data files
-        os.remove('test_chirp_common.py')
-        os.remove('test_mock_chirp.py')
-
-    @staticmethod
-    def create_test_data_files():
-        # Create a test chirp_common.py file
-        with open('test_chirp_common.py', 'w') as file:
-            file.write("{'CONSTANT_A': 1, 'CONSTANT_B': 2}")
-
-        # Create a test mock_chirp.py file
-        with open('test_mock_chirp.py', 'w') as file:
-            file.write("{'CONSTANT_A': 1, 'CONSTANT_C': 3}")
-
     def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.old_cwd = os.getcwd()
+        os.chdir(self.temp_dir.name)
+
         self.updater = UpdateMockChirp()
-        self.updater.CHIRP_COMMON_FILENAME = 'test_chirp_common.py'
-        self.updater.MOCK_CHIRP_FILENAME = 'test_mock_chirp.py'
+        self.updater.CHIRP_COMMON_FILENAME = "test_chirp_common.py"
+        self.updater.MOCK_CHIRP_FILENAME = "test_mock_chirp.py"
+
+    def tearDown(self):
+        os.chdir(self.old_cwd)
+        self.temp_dir.cleanup()
 
     def test_parse_chirp_common(self):
-        # Test parsing chirp_common.py
-        with open('test_chirp_common.py', 'w') as file:
-            file.write("CONSTANT_A = 1\nCONSTANT_B = 2\n")
+        with open("test_chirp_common.py", "w", encoding="utf-8") as file:
+            file.write(
+                "from chirp import errors\n"
+                "TONES = (67.0, 69.3)\n"
+                "DTCS_CODES = (23, 25)\n"
+                "not_a_constant = 'ignored'\n"
+            )
 
-        expected = {'CONSTANT_A': 1, 'CONSTANT_B': 2}
+        expected = {
+            "TONES": (67.0, 69.3),
+            "DTCS_CODES": (23, 25),
+        }
+
         result = self.updater.parse_chirp_common()
+
         self.assertEqual(result, expected)
 
     def test_parse_mock_chirp(self):
-        # TODO improve the contents of the mock_chirp.py file to include
-        #  irrelevant declarations, variables and functions
-        # Test parsing mock_chirp.py
-        self.updater.MOCK_CHIRP_FILENAME = 'test_mock_chirp.py'
-        expected = {'CONSTANT_A': 1, 'CONSTANT_C': 3}
+        with open("test_mock_chirp.py", "w", encoding="utf-8") as file:
+            file.write(
+                "class MockChirp:\n"
+                "    TONES = (67.0, 69.3)\n"
+                "    DTCS_CODES = (23, 25)\n"
+                "    helper = 'ignored'\n"
+            )
+
+        expected = {
+            "TONES": (67.0, 69.3),
+            "DTCS_CODES": (23, 25),
+        }
+
         result = self.updater.parse_mock_chirp()
+
         self.assertEqual(result, expected)
 
     def test_compare_constants(self):
-        # Test comparing constants between chirp_common and mock_chirp
-        common_constants = {'CONSTANT_A': 1, 'CONSTANT_B': 2}
-        mock_constants = {'CONSTANT_A': 1, 'CONSTANT_C': 3}
-        expected_updated = True
-        expected_mock_constants = {'CONSTANT_A': 1, 'CONSTANT_B': 2, 'CONSTANT_C': 3}
-        updated, result = self.updater.compare_constants(common_constants,
-                                                         mock_constants)
-        self.assertEqual(updated, expected_updated)
-        self.assertEqual(result, expected_mock_constants)
+        common_constants = {
+            "TONES": (67.0, 69.3),
+            "DTCS_CODES": (23, 25),
+            "MODES": ("FM",),
+        }
+        mock_constants = {
+            "TONES": (67.0,),
+            "DTCS_CODES": (23, 25),
+            "CHIRP_SOURCES": ["local-only"],
+        }
+
+        updated, result = self.updater.compare_constants(
+            common_constants,
+            mock_constants,
+        )
+
+        self.assertTrue(updated)
+        self.assertEqual(result["TONES"], (67.0, 69.3))
+        self.assertEqual(result["DTCS_CODES"], (23, 25))
+        self.assertEqual(result["CHIRP_SOURCES"], ["local-only"])
+        self.assertNotIn("MODES", result)
 
     def test_update_mock_chirp(self):
-        # Test updating mock_chirp.py
-        self.updater.MOCK_CHIRP_FILENAME = 'test_mock_chirp.py'
-        mock_constants = {'CONSTANT_A': 1, 'CONSTANT_B': 2, 'CONSTANT_C': 3}
+        with open("test_mock_chirp.py", "w", encoding="utf-8") as file:
+            file.write(
+                "class MockChirp:\n"
+                "    TONES = (67.0,)\n"
+                "    DTCS_CODES = (23,)\n"
+                "\n"
+                "class Other:\n"
+                "    TONES = ('leave-alone',)\n"
+            )
+
+        mock_constants = {
+            "TONES": (67.0, 69.3),
+            "DTCS_CODES": (23, 25),
+        }
+
         self.updater.update_mock_chirp(mock_constants)
-        with open('test_mock_chirp.py', 'r') as file:
-            result = ast.literal_eval(file.read())
-        self.assertEqual(result, mock_constants)
+
+        with open("test_mock_chirp.py", "r", encoding="utf-8") as file:
+            result = file.read()
+
+        self.assertIn("    TONES = (67.0, 69.3)\n", result)
+        self.assertIn("    DTCS_CODES = (23, 25)\n", result)
+        self.assertIn("    TONES = ('leave-alone',)\n", result)
+
+        parsed = ast.parse(result)
+        self.assertIsInstance(parsed, ast.Module)
 
     def test_commit_and_create_pr(self):
-        # Test commit and create PR functionality
-        # This is a placeholder test as it requires GitHub API interaction
-        # You can mock the subprocess calls or use a library like unittest.mock
         pass
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #63

This PR addresses the failing update mock chirp GitHub action.

## Problem
The update mock chirp action is failing as reported in #63.

## Solution
- [ ] Investigate the root cause of the action failure
- [ ] Fix the issue
- [ ] Verify the action runs successfully

**Status**: Work in progress